### PR TITLE
Enable HTTPS URL protocol on native images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ solanum: reflection-config := svm/reflection-config.json
 solanum: target/uberjar/solanum.jar $(reflection-config)
 	$(GRAAL_PATH)/bin/native-image \
 	    --report-unsupported-elements-at-runtime \
+	    --enable-url-protocols=https \
 	    --delay-class-initialization-to-runtime=io.netty.handler.ssl.ReferenceCountedOpenSslEngine \
 	    -H:ReflectionConfigurationFiles=$(reflection-config) \
 	    -J-Xmx3G -J-Xms3G \


### PR DESCRIPTION
Currently the http source blows up when given an https:// URL.