### PR TITLE
Improve measuring linux process

### DIFF
--- a/src/solanum/source/process.clj
+++ b/src/solanum/source/process.clj
@@ -19,7 +19,7 @@
   "Parse a line of output from the `ps` command and return a map with
   information about each process."
   [line]
-  (when-let [[_ pid rss vsize state user group lstart command] (re-matches #"(\d+) +(\d+) +(\d+) +(.) +(\S+) +(\S+) +(\w+ +\w+ +\d+ +\d\d:\d\d:\d\d \d+) +(.+)" line)]
+  (when-let [[_ pid rss vsize state user group lstart command] (re-matches #" *(\d+) +(\d+) +(\d+) +(.) +(\S+) +(\S+) +(\w+ +\w+ +\d+ +\d\d:\d\d:\d\d \d+) +(.+)" line)]
     {:pid (Long/parseLong pid)
      :rss (Long/parseLong rss)
      :vsize (Long/parseLong vsize)
@@ -41,7 +41,7 @@
 (defn- measure-linux
   "Measure process stats on a Linux system."
   []
-  (let [result (shell/sh "ps" "axo" "pid=,rss=,vsize=,state=,user=,group=,lstart=,command=")]
+  (let [result (shell/sh "ps" "axo" "pid=,rss=,vsize=,state=,user:32=,group:32=,lstart=,command=")]
     (if (zero? (:exit result))
       ; IDEA: capture process fd usage and thread counts?
       (keep parse-linux-process (str/split (:out result) #"\n"))


### PR DESCRIPTION
`ps` formatting can have leading spaces in front of pids because ps pads the pid column with spaces to make the result more readable. This change will allows solanum find lower numbered processes that previously would be ignored because of a leading space. (E.G. ' 123' and '4567') 
This change also increase the user and group widths to the max user width, so that solanum can match on users greater the the default length, 8. 