### PR TITLE
Use RiemannClient.connect instead of RiemannClient.reconnect

### DIFF
--- a/src/solanum/output/riemann.clj
+++ b/src/solanum/output/riemann.clj
@@ -45,7 +45,7 @@
   (write-events
     [this events]
     (when-not (riemann/connected? client)
-      (riemann/reconnect! client))
+      (riemann/connect! client))
     @(riemann/send-events client (prepare-batch events))))
 
 


### PR DESCRIPTION
The underlying reconnect method on the TcpTransport class is broken and
cannot be called after the initial connection is made. connect is a noop
after the initial connection is made and defines a background handler to
reestablish the connection when it is broken.

This should resolve issue #14.